### PR TITLE
Fix/embed: support the Argo API syntax at v1/embed

### DIFF
--- a/src/argoproxy/app.py
+++ b/src/argoproxy/app.py
@@ -25,7 +25,7 @@ async def proxy_argo_chat_directly(request: web.Request):
 
 async def proxy_embedding_directly(request: web.Request):
     logger.info("/v1/embed")
-    return await embed.proxy_request(request, convert_to_openai=True)
+    return await embed.proxy_request(request, convert_to_openai=False)
 
 
 # ================= OpenAI Compatible =================

--- a/src/argoproxy/endpoints/chat.py
+++ b/src/argoproxy/endpoints/chat.py
@@ -265,7 +265,7 @@ async def send_streaming_request(
                 k: v
                 for k, v in upstream_resp.headers.items()
                 if k.lower()
-                not in ("Content-Type", "content-encoding", "transfer-encoding")
+                not in ("content-type", "content-encoding", "transfer-encoding")
             }
         )
         response = web.StreamResponse(

--- a/src/argoproxy/endpoints/embed.py
+++ b/src/argoproxy/endpoints/embed.py
@@ -96,10 +96,13 @@ async def proxy_request(
 
         # Transform the incoming payload to match the destination API format
         data["user"] = config.user
-        data["prompt"] = (
-            [data["input"]] if not isinstance(data["input"], list) else data["input"]
-        )
-        del data["input"]
+        if 'prompt' not in data: # argo-API uses prompt, openAI-API uses input
+            if 'input' not in data:
+                raise ValueError("No 'input' (openAI) or 'prompt' (Argo) field present in the input data.")
+            data["prompt"] = (
+                [data["input"]] if not isinstance(data["input"], list) else data["input"]
+            )
+            del data["input"]
 
         headers: Dict[str, str] = {"Content-Type": "application/json"}
 


### PR DESCRIPTION
If I understand right, v1/embed is intended as a transparent interface to Argo embed. I believe we need to support the 'prompt' (not 'input') following Argo API and don't transform the returned objects to openAI? 